### PR TITLE
Update Api.php

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Api.php
+++ b/app/code/community/Adyen/Payment/Model/Api.php
@@ -337,8 +337,8 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
             if (!$token) {
                 Mage::throwException(Mage::helper('adyen')->__('Missing token'));
             }
-
-            $request['paymentMethod']['applepay.token'] = base64_encode($token);
+            $request['paymentMethod']['type'] = 'applepay';
+            $request['paymentMethod']['additionalData.applepay.token'] = base64_encode($token);
         }
 
         return $request;


### PR DESCRIPTION
Use proper payment fields in the request according to the documentation https://docs.adyen.com/payment-methods/apple-pay/custom-integration-apple-pay-web/

**Description**
When place an order with ApplePay (Sandbox account) it shows and error
"Payment Not Complete"
and in logs adyen_exception.log i can see and error
```log
Adyen_Payment_Exception: HTTP Status code 422 received, data {"status":422,"errorCode":"14_007","message":"Invalid payment method data","errorType":"validation"} in app/code/community/Adyen/Payment/Exception.php:43
```

**Tested scenarios**
- use iPhone with touchID
- log in to iCloud with sandbox account
- got to web-shop
- add product to card
- got to checkout
- fill in all required fields up to payment method step
- choose ApplePay ad payment method and go to next step
- tap on ApplePay button on review
- in appeared popup select test card listed on https://developer.apple.com/apple-pay/sandbox-testing/
- use passcode(or touchID)

Expected result: place and order

**Fixed issue**:  #1024